### PR TITLE
ci: bump Node to lts/* and update actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '14.x'
+          node-version: 'lts/*'
       - run: |
           yarn
           yarn cov


### PR DESCRIPTION
Node 14 in CI is EOL and no longer satisfies transitive dependency requirements (e.g. node-releases needs >=18 after the @babel/core bump in #76). Moves CI to lts/* with actions/checkout@v4 and actions/setup-node@v4.